### PR TITLE
fixed SyntaxError: Unexpected token 'import'

### DIFF
--- a/lib/commands/import.js
+++ b/lib/commands/import.js
@@ -6,7 +6,7 @@ const forageLock = JSON.parse(fs.readFileSync('forage.lock', 'utf8')); // TODO a
 const forage = require('../forage');
 const async = require('async');
 
-async function import(argv) {
+module.exports = async (argv) => {
   var db = forage.connectDB()
   await forage.connectIPFS(db, argv.topic);
 
@@ -25,5 +25,3 @@ async function import(argv) {
     process.exit(0)
   })
 }
-
-module.exports = import


### PR DESCRIPTION
`forage import` used to fail with the following error message: `SyntaxError: Unexpected token 'import'`. Now it should no longer do this.